### PR TITLE
Fix ruff lint errors in Workflows/ and tests/

### DIFF
--- a/Workflows/EV_curve.py_fix.py
+++ b/Workflows/EV_curve.py_fix.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.calculator.data import OutputSEFS
 from pyiron_nodes.atomistic.calculator.generic import ApplyEngine, CreateSEFSContainer
 from pyiron_nodes.atomistic.engine.ase import GRACE
@@ -6,8 +7,6 @@ from pyiron_nodes.controls import IterToDataFrame
 from pyiron_nodes.dataframe import GetColumnFromDataFrame
 from pyiron_nodes.math_utils import Linspace
 from pyiron_nodes.plotting import Plot
-from core import Workflow
-from core import group_node
 
 wf = Workflow("EV_curve")
 

--- a/Workflows/GaN_surfaces.py
+++ b/Workflows/GaN_surfaces.py
@@ -1,8 +1,7 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.atomistic.structure.transform import Repeat
 from pyiron_nodes.atomistic.structure.view import Plot3d
-from core import Workflow
-from core import group_node
 
 wf = Workflow("GaN_surfaces")
 

--- a/Workflows/ML_model_selection.py
+++ b/Workflows/ML_model_selection.py
@@ -1,13 +1,12 @@
+from core import Workflow, group_node
 from pyiron_nodes.dataframe import ReadDataFrame
-from pyiron_nodes.machine_learning.pipeline import ChooseBestModel, MLDataSplitter
 from pyiron_nodes.machine_learning.models import (
     EvaluateRegressionModelSklearn,
     LinearRegressionModel,
     PredictRegressionModel,
     SupportVectorRegressionModel,
 )
-from core import Workflow
-from core import group_node
+from pyiron_nodes.machine_learning.pipeline import ChooseBestModel, MLDataSplitter
 
 wf = Workflow("simple_inference")
 

--- a/Workflows/ace_linear_fit.py
+++ b/Workflows/ace_linear_fit.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.ml_potentials.fitting.linearfit import (
     ParameterizePotentialConfig,
     PlotEnergyFittingCurve,
@@ -6,8 +7,6 @@ from pyiron_nodes.atomistic.ml_potentials.fitting.linearfit import (
     RunLinearFit,
     SplitTrainingAndTesting,
 )
-from core import Workflow
-from core import group_node
 
 wf = Workflow("ace_linear_fit")
 

--- a/Workflows/al_relax_vs_static.py
+++ b/Workflows/al_relax_vs_static.py
@@ -1,4 +1,6 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.engine.ase import GRACE
+from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.controls import IterToDataFrame
 from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
     GenericOptimizerSettings,
@@ -6,11 +8,8 @@ from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
     Relax,
     Static,
 )
-from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.math_utils import Linspace
 from pyiron_nodes.plotting import InputPlotOptions, MergePlots, PlotDataFrame
-from core import Workflow
-from core import group_node
 
 wf = Workflow("al_relax_vs_static")
 

--- a/Workflows/assyst.py
+++ b/Workflows/assyst.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.engine.ase import GRACE
 from pyiron_nodes.dataframe import GetColumnFromDataFrame
 from pyiron_nodes.dpg2026.atomistic.assyst.stoichiometry import (
@@ -18,8 +19,6 @@ from pyiron_nodes.plotting import (
     MergePlots,
     Scatter,
 )
-from core import Workflow
-from core import group_node
 
 wf = Workflow("assyst")
 

--- a/Workflows/calph_melt.py
+++ b/Workflows/calph_melt.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.atomistic.structure.transform import Repeat
 from pyiron_nodes.dpg2026.atomistic.calculator.calphy import (
@@ -8,8 +9,6 @@ from pyiron_nodes.dpg2026.atomistic.calculator.calphy import (
 from pyiron_nodes.dpg2026.atomistic.engine.lammps import ListPotentials
 from pyiron_nodes.dpg2026.atomistic.structure.transform import Rattle
 from pyiron_nodes.plotting import InputPlotOptions, MergePlots, Plot
-from core import Workflow
-from core import group_node
 
 wf = Workflow("calph_melt")
 

--- a/Workflows/calphy_solid.py
+++ b/Workflows/calphy_solid.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.atomistic.structure.transform import Repeat
 from pyiron_nodes.dpg2026.atomistic.calculator.calphy import (
@@ -6,8 +7,6 @@ from pyiron_nodes.dpg2026.atomistic.calculator.calphy import (
 )
 from pyiron_nodes.dpg2026.atomistic.engine.lammps import ListPotentials
 from pyiron_nodes.plotting import InputPlotOptions, Plot
-from core import Workflow
-from core import group_node
 
 wf = Workflow("calphy_solid")
 

--- a/Workflows/db_table.py
+++ b/Workflows/db_table.py
@@ -1,3 +1,4 @@
+from core import Workflow
 from pyiron_nodes.databases.node_hash_db import (
     CreateDB,
     DeleteDB,
@@ -9,7 +10,6 @@ from pyiron_nodes.databases.node_hash_db import (
     GetUpstreamGraph,
     ShowTable,
 )
-from core import Workflow
 
 wf = Workflow("db_table")
 

--- a/Workflows/electrochemistry_cell.py
+++ b/Workflows/electrochemistry_cell.py
@@ -1,8 +1,7 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.structure.build import Surface
 from pyiron_nodes.atomistic.structure.view import Plot3d
 from pyiron_nodes.electrochemistry.structure.build import add_neon_layer, add_water_film
-from core import Workflow
-from core import group_node
 
 wf = Workflow("electrochemistry_cell")
 

--- a/Workflows/erg_vol_iter.py
+++ b/Workflows/erg_vol_iter.py
@@ -1,17 +1,16 @@
+from core import Workflow, group_node
 from pyiron_nodes.controls import IterToDataFrame
 from pyiron_nodes.math_utils import Linspace
-from core import Workflow
-from core import group_node
 
 # ── Group node factories ─────────────────────────────
 
 
 @group_node("out")
 def Bulk_GRACE_Static_Energy(name, a=None, cubic=False):
+    from core import Workflow
     from pyiron_nodes.atomistic.calculator.ase import Static
     from pyiron_nodes.atomistic.engine.ase import GRACE
     from pyiron_nodes.atomistic.structure.build import Bulk
-    from core import Workflow
 
     inner_wf = Workflow("Bulk_GRACE_Static_Energy")
     inner_wf.Bulk = Bulk(name=name, a=a, cubic=cubic)

--- a/Workflows/erg_vs_vol.py
+++ b/Workflows/erg_vs_vol.py
@@ -1,17 +1,16 @@
+from core import Workflow, group_node
 from pyiron_nodes.controls import IterToDataFrame
 from pyiron_nodes.math_utils import Linspace
-from core import Workflow
-from core import group_node
 
 # ── Group node factories ─────────────────────────────
 
 
 @group_node("out")
 def group_Bulk_GRACE_Static(name, a=None, cubic=False):
+    from core import Workflow
     from pyiron_nodes.atomistic.calculator.ase import StaticEnergy
     from pyiron_nodes.atomistic.engine.ase import GRACE
     from pyiron_nodes.atomistic.structure.build import Bulk
-    from core import Workflow
 
     inner_wf = Workflow("group_Bulk_GRACE_Static")
     inner_wf.Bulk = Bulk(name=name, a=a, cubic=cubic)

--- a/Workflows/h_diffusion_EMT.py
+++ b/Workflows/h_diffusion_EMT.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.diffusion import AddInterstitialH, PlotNEBPath, RunNEB
 from pyiron_nodes.atomistic.engine.ase import EMT
 from pyiron_nodes.atomistic.structure.build import Bulk
@@ -7,8 +8,6 @@ from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
     Relax,
 )
 from pyiron_nodes.dpg2026.atomistic.structure.transform import Repeat
-from core import Workflow
-from core import group_node
 
 wf = Workflow("h_diffusion_EMT")
 

--- a/Workflows/h_diffusion_GRACE.py
+++ b/Workflows/h_diffusion_GRACE.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.diffusion import (
     AddInterstitialH,
     InterstitialHPositions,
@@ -12,8 +13,6 @@ from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
     Relax,
 )
 from pyiron_nodes.dpg2026.atomistic.structure.transform import Repeat
-from core import Workflow
-from core import group_node
 
 wf = Workflow("h_diffusion_GRACE")
 

--- a/Workflows/h_diffusion_GRACE_md.py
+++ b/Workflows/h_diffusion_GRACE_md.py
@@ -1,3 +1,4 @@
+from core import Workflow
 from pyiron_nodes.atomistic.calculator.data import InputCalcMD, OutputCalcMD
 from pyiron_nodes.atomistic.diffusion import (
     AddInterstitialH,
@@ -16,7 +17,6 @@ from pyiron_nodes.atomistic.engine.ase import GRACE
 from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.dpg2026.atomistic.structure.transform import Repeat
 from pyiron_nodes.plotting import Plot
-from core import Workflow
 
 wf = Workflow("h_diffusion_GRACE_md")
 

--- a/Workflows/h_diffusion_in_fcc_al.py
+++ b/Workflows/h_diffusion_in_fcc_al.py
@@ -1,12 +1,12 @@
+from core import Workflow
+from pyiron_nodes.atomistic.diffusion import AddInterstitialH, PlotNEBPath, RunNEB
+from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
     GenericOptimizerSettings,
     Relax,
 )
 from pyiron_nodes.dpg2026.atomistic.engine.grace import Grace
-from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.dpg2026.atomistic.structure.transform import Repeat
-from pyiron_nodes.atomistic.diffusion import AddInterstitialH, PlotNEBPath, RunNEB
-from core import Workflow
 
 wf = Workflow("h_diffusion_in_fcc_al")
 

--- a/Workflows/h_diffusion_lammps_md.py
+++ b/Workflows/h_diffusion_lammps_md.py
@@ -1,13 +1,5 @@
+from core import Workflow
 from pyiron_nodes.atomistic.calculator.data import InputCalcMD, OutputCalcMD
-from pyiron_nodes.atomistic.engine.lammps import (
-    CreateLammpsMDInput,
-    CreateLammpsStructure,
-    ListPotentials,
-    ParseLammpsOutput,
-    RunLammpsCalculation,
-)
-from pyiron_nodes.atomistic.structure.build import Bulk
-from pyiron_nodes.atomistic.structure.transform import FixSpecies, Repeat
 from pyiron_nodes.atomistic.diffusion import (
     AddInterstitialH,
     AugmentWithSymmetry,
@@ -20,9 +12,17 @@ from pyiron_nodes.atomistic.diffusion import (
     PlotHPositions,
     PlotMigrationPath,
 )
+from pyiron_nodes.atomistic.engine.lammps import (
+    CreateLammpsMDInput,
+    CreateLammpsStructure,
+    ListPotentials,
+    ParseLammpsOutput,
+    RunLammpsCalculation,
+)
+from pyiron_nodes.atomistic.structure.build import Bulk
+from pyiron_nodes.atomistic.structure.transform import FixSpecies, Repeat
 from pyiron_nodes.controls import pick_element
 from pyiron_nodes.plotting import Plot
-from core import Workflow
 
 wf = Workflow("h_diffusion_lammps_md")
 

--- a/Workflows/h_diffusion_lammps_neb2.py
+++ b/Workflows/h_diffusion_lammps_neb2.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.diffusion import (
     AddInterstitialH,
     LammpsAseEngine,
@@ -12,8 +13,6 @@ from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
     Relax,
 )
 from pyiron_nodes.dpg2026.atomistic.structure.transform import Repeat
-from core import Workflow
-from core import group_node
 
 wf = Workflow("h_diffusion_lammps_neb2")
 

--- a/Workflows/h_diffusion_md.py
+++ b/Workflows/h_diffusion_md.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.calculator.data import OutputCalcMD
 from pyiron_nodes.atomistic.diffusion import (
     ComputeMSD,
@@ -8,18 +9,16 @@ from pyiron_nodes.atomistic.diffusion import (
     PlotMigrationPath,
 )
 from pyiron_nodes.plotting import Plot
-from core import Workflow
-from core import group_node
 
 # ── Group node factories ─────────────────────────────
 
 
 @group_node("new_structure", "structure")
 def Supercell(name, cubic=False, repeat_scalar=1, al_h_structure__repeat_scalar=1):
+    from core import Workflow
     from pyiron_nodes.atomistic.diffusion import AddInterstitialH
     from pyiron_nodes.atomistic.structure.build import Bulk
     from pyiron_nodes.atomistic.structure.transform import FixSpecies, Repeat
-    from core import Workflow
 
     inner_wf = Workflow("Supercell")
     inner_wf.al_bulk = Bulk(name=name, cubic=cubic)
@@ -54,6 +53,7 @@ def Lammps(
     working_directory=".",
     store=False,
 ):
+    from core import Workflow
     from pyiron_nodes.atomistic.calculator.data import InputCalcMD
     from pyiron_nodes.atomistic.engine.lammps import (
         CreateLammpsMDInput,
@@ -63,7 +63,6 @@ def Lammps(
         RunLammpsCalculation,
     )
     from pyiron_nodes.controls import pick_element
-    from core import Workflow
 
     inner_wf = Workflow("Lammps")
     inner_wf.list_potentials = ListPotentials(structure=list_potentials__structure)
@@ -102,12 +101,12 @@ def Lammps(
 
 @group_node("free_energy", "grid_centers", "augmented_positions")
 def FreeEnergySurface(al_bulk, augmented_h_pos__al_bulk, md_output, md_input):
+    from core import Workflow
     from pyiron_nodes.atomistic.diffusion import (
         AugmentWithSymmetry,
         ComputeFreeEnergySurface,
         FoldPositionsToUnitCell,
     )
-    from core import Workflow
 
     inner_wf = Workflow("FreeEnergySurface")
     inner_wf.folded_h_pos = FoldPositionsToUnitCell(

--- a/Workflows/h_diffusion_neb.py
+++ b/Workflows/h_diffusion_neb.py
@@ -1,20 +1,19 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.diffusion import AddInterstitialH, PlotNEBPath, RunNEB
 from pyiron_nodes.atomistic.structure.view import Animate
 from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
     GenericOptimizerSettings,
     Relax,
 )
-from core import Workflow
-from core import group_node
 
 # ── Group node factories ─────────────────────────────
 
 
 @group_node("structure")
 def Bulk(name, cubic=False, repeat_scalar=1):
+    from core import Workflow
     from pyiron_nodes.atomistic.structure.build import Bulk
     from pyiron_nodes.dpg2026.atomistic.structure.transform import Repeat
-    from core import Workflow
 
     inner_wf = Workflow("Bulk")
     inner_wf.al_unit = Bulk(name=name, cubic=cubic)
@@ -26,10 +25,10 @@ def Bulk(name, cubic=False, repeat_scalar=1):
 
 @group_node("engine")
 def LammpsEngine(structure, index):
+    from core import Workflow
     from pyiron_nodes.atomistic.diffusion import LammpsAseEngine
     from pyiron_nodes.atomistic.engine.lammps import ListPotentials
     from pyiron_nodes.controls import pick_element
-    from core import Workflow
 
     inner_wf = Workflow("LammpsEngine")
     inner_wf.list_potentials = ListPotentials(structure=structure)

--- a/Workflows/h_diffusion_neb_lammps.py
+++ b/Workflows/h_diffusion_neb_lammps.py
@@ -1,19 +1,19 @@
-from pyiron_nodes.atomistic.engine.lammps import ListPotentials, CreateLammpsStructure
-from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
-    GenericOptimizerSettings,
-    Relax,
-)
-from pyiron_nodes.atomistic.structure.build import Bulk
-from pyiron_nodes.dpg2026.atomistic.structure.transform import Repeat
+from core import Workflow
 from pyiron_nodes.atomistic.diffusion import (
     AddInterstitialH,
     LammpsAseEngine,
     PlotNEBPath,
     RunNEB,
 )
-from pyiron_nodes.plotting import Plot
+from pyiron_nodes.atomistic.engine.lammps import CreateLammpsStructure, ListPotentials
+from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.controls import pick_element
-from core import Workflow
+from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
+    GenericOptimizerSettings,
+    Relax,
+)
+from pyiron_nodes.dpg2026.atomistic.structure.transform import Repeat
+from pyiron_nodes.plotting import Plot
 
 wf = Workflow("h_diffusion_neb_lammps")
 

--- a/Workflows/iter_demo.py
+++ b/Workflows/iter_demo.py
@@ -1,8 +1,7 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.controls import IterToDataFrame
 from pyiron_nodes.math_utils import Linspace
-from core import Workflow
-from core import group_node
 
 wf = Workflow("iter_demo")
 

--- a/Workflows/lammps_md.py
+++ b/Workflows/lammps_md.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.calculator.data import InputCalcMD, OutputCalcMD
 from pyiron_nodes.atomistic.engine.lammps import (
     CreateLammpsMDInput,
@@ -10,8 +11,6 @@ from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.atomistic.structure.transform import FixSpecies, Repeat
 from pyiron_nodes.atomistic.structure.view import Animate
 from pyiron_nodes.controls import pick_element
-from core import Workflow
-from core import group_node
 
 wf = Workflow("lammps_md")
 

--- a/Workflows/lammps_md_basic.py
+++ b/Workflows/lammps_md_basic.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.calculator.data import InputCalcMD, OutputCalcMD
 from pyiron_nodes.atomistic.engine.lammps import (
     CreateLammpsMDInput,
@@ -10,8 +11,6 @@ from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.atomistic.structure.transform import Repeat
 from pyiron_nodes.controls import pick_element
 from pyiron_nodes.plotting import Plot
-from core import Workflow
-from core import group_node
 
 wf = Workflow("lammps_md_basic")
 

--- a/Workflows/lammps_md_group_py.py
+++ b/Workflows/lammps_md_group_py.py
@@ -1,17 +1,16 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.calculator.data import InputCalcMD, OutputCalcMD
 from pyiron_nodes.atomistic.structure.transform import FixSpecies
 from pyiron_nodes.atomistic.structure.view import Animate
-from core import Workflow
-from core import group_node
 
 # ── Group node factories ─────────────────────────────
 
 
 @group_node("structure")
 def Structure(name, cubic=False, repeat_scalar=1):
+    from core import Workflow
     from pyiron_nodes.atomistic.structure.build import Bulk
     from pyiron_nodes.atomistic.structure.transform import Repeat
-    from core import Workflow
 
     inner_wf = Workflow("Structure")
     inner_wf.Bulk = Bulk(name=name, cubic=cubic)
@@ -21,9 +20,9 @@ def Structure(name, cubic=False, repeat_scalar=1):
 
 @group_node("element")
 def GetPotential(structure, index):
+    from core import Workflow
     from pyiron_nodes.atomistic.engine.lammps import ListPotentials
     from pyiron_nodes.controls import pick_element
-    from core import Workflow
 
     inner_wf = Workflow("GetPotential")
     inner_wf.ListPotentials = ListPotentials(structure=structure)
@@ -33,13 +32,13 @@ def GetPotential(structure, index):
 
 @group_node("out")
 def Lammps(calc_dataclass, structure, potential, working_directory="."):
+    from core import Workflow
     from pyiron_nodes.atomistic.engine.lammps import (
         CreateLammpsMDInput,
         CreateLammpsStructure,
         ParseLammpsOutput,
         RunLammpsCalculation,
     )
-    from core import Workflow
 
     inner_wf = Workflow("Lammps")
     inner_wf.CreateLammpsStructure = CreateLammpsStructure(

--- a/Workflows/lammps_minimize_basic.py
+++ b/Workflows/lammps_minimize_basic.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.calculator.data import (
     InputCalcMinimize,
     OutputCalcMinimize,
@@ -13,8 +14,6 @@ from pyiron_nodes.atomistic.engine.lammps import (
 from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.atomistic.structure.transform import Repeat
 from pyiron_nodes.controls import pick_element
-from core import Workflow
-from core import group_node
 
 wf = Workflow("lammps_minimize_basic")
 

--- a/Workflows/lammps_static_basic.py
+++ b/Workflows/lammps_static_basic.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.calculator.data import OutputCalcStatic
 from pyiron_nodes.atomistic.engine.lammps import (
     CreateLammpsStaticInput,
@@ -9,8 +10,6 @@ from pyiron_nodes.atomistic.engine.lammps import (
 from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.atomistic.structure.transform import Repeat
 from pyiron_nodes.controls import pick_element
-from core import Workflow
-from core import group_node
 
 wf = Workflow("lammps_static_basic")
 

--- a/Workflows/mg_ca_surface_diagram.py
+++ b/Workflows/mg_ca_surface_diagram.py
@@ -1,13 +1,12 @@
+import pandas as pd
+from ase import Atoms
+from core import Workflow, as_function_node, group_node
 from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
     GenericOptimizerSettings,
     Relax,
 )
 from pyiron_nodes.dpg2026.atomistic.engine.grace import Grace
-from core import Workflow
-from core import group_node
-from core import as_function_node
-import pandas as pd
 
 # ── Local node definitions ──────────────────────
 
@@ -27,10 +26,10 @@ def BuildDecoratedStructures(
     Columns: structure (ASE Atoms), name (str, legend label).
     """
     from pyiron_nodes.atomistic.structure.build_point_defects import (
-        make_pristine_reference,
-        make_config_row,
-        op_substitute,
         expand_configs,
+        make_config_row,
+        make_pristine_reference,
+        op_substitute,
     )
 
     atoms0, pristine_pos = make_pristine_reference._original_func(host_structure)
@@ -116,8 +115,8 @@ def ChemicalPotentialSweep(
 
 @group_node("surface")
 def mg_surface(size="1 1 1", vacuum=1.0):
-    from pyiron_nodes.atomistic.structure.build import Surface
     from core import Workflow
+    from pyiron_nodes.atomistic.structure.build import Surface
 
     inner_wf = Workflow("mg_surface")
     inner_wf.slab = Surface(
@@ -128,9 +127,8 @@ def mg_surface(size="1 1 1", vacuum=1.0):
 
 @group_node("mu")
 def mu_mg(structure, engine, optimizer_settings=None):
+    from core import Workflow, as_function_node
     from pyiron_nodes.dpg2026.atomistic.calculator.optimize import Relax
-    from core import Workflow
-    from core import as_function_node
 
     @as_function_node("mu")
     def _energy_per_atom(calc_result):
@@ -155,9 +153,8 @@ def mu_mg(structure, engine, optimizer_settings=None):
 
 @group_node("mu")
 def mu_ca_ref(structure, engine, optimizer_settings=None):
+    from core import Workflow, as_function_node
     from pyiron_nodes.dpg2026.atomistic.calculator.optimize import Relax
-    from core import Workflow
-    from core import as_function_node
 
     @as_function_node("mu")
     def _energy_per_atom(calc_result):
@@ -182,13 +179,12 @@ def mu_ca_ref(structure, engine, optimizer_settings=None):
 
 @group_node("result")
 def FormationEnergies(df, mu_host, mu_solute):
+    from core import Workflow, as_function_node
     from pyiron_nodes.atomistic.thermodynamics.defect_phases import (
         AddDefectConcentrationColumns,
         AddElementCountColumns,
         ComputeDefectFormationEnergy,
     )
-    from core import Workflow
-    from core import as_function_node
 
     @as_function_node("chemical_potentials")
     def _pack_chemical_potentials(mu_host, mu_solute, host="Mg", solute="Ca"):

--- a/Workflows/optimize.py
+++ b/Workflows/optimize.py
@@ -1,11 +1,10 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.engine.ase import GRACE
+from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
     GenericOptimizerSettings,
     Relax,
 )
-from pyiron_nodes.atomistic.structure.build import Bulk
-from core import Workflow
-from core import group_node
 
 wf = Workflow("optimize")
 

--- a/Workflows/optimize_loop.py
+++ b/Workflows/optimize_loop.py
@@ -1,14 +1,13 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.engine.ase import GRACE
+from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.controls import iterate
 from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
     GenericOptimizerSettings,
     MapCalculatorOnStructures,
     Relax,
 )
-from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.math_utils import Linspace
-from core import Workflow
-from core import group_node
 
 wf = Workflow("optimize_loop")
 

--- a/Workflows/point_def_energies.py
+++ b/Workflows/point_def_energies.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.thermodynamics.defect_phases import (
     AddDefectConcentrationColumns,
     AddElementCountColumns,
@@ -8,14 +9,13 @@ from pyiron_nodes.atomistic.thermodynamics.defect_phases import (
 from pyiron_nodes.controls import IterToDataFrame
 from pyiron_nodes.dataframe import GetColumnFromDataFrame
 from pyiron_nodes.math_utils import Linspace
-from core import Workflow
-from core import group_node
 
 # ── Group node factories ─────────────────────────────
 
 
 @group_node("table")
 def CreateStructures(name, element, cubic=False, repeat_scalar=1):
+    from core import Workflow
     from pyiron_nodes.atomistic.structure.build import Bulk
     from pyiron_nodes.atomistic.structure.container import (
         AddPristine,
@@ -24,7 +24,6 @@ def CreateStructures(name, element, cubic=False, repeat_scalar=1):
         GetStructureTable,
     )
     from pyiron_nodes.atomistic.structure.transform import Repeat
-    from core import Workflow
 
     inner_wf = Workflow("CreateStructures")
     inner_wf.Bulk = Bulk(name=name, cubic=cubic)
@@ -45,9 +44,9 @@ def CreateStructures(name, element, cubic=False, repeat_scalar=1):
 
 @group_node("energy")
 def group_GRACE_StaticEnergy(structure):
+    from core import Workflow
     from pyiron_nodes.atomistic.calculator.ase import StaticEnergy
     from pyiron_nodes.atomistic.engine.ase import GRACE
-    from core import Workflow
 
     inner_wf = Workflow("group_GRACE_StaticEnergy")
     inner_wf.GRACE = GRACE()

--- a/Workflows/point_defect_metals_energies.py
+++ b/Workflows/point_defect_metals_energies.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.thermodynamics.defect_phases import (
     AddDefectConcentrationColumns,
     AddElementCountColumns,
@@ -8,8 +9,6 @@ from pyiron_nodes.atomistic.thermodynamics.defect_phases import (
 from pyiron_nodes.controls import IterToDataFrame
 from pyiron_nodes.dataframe import GetColumnFromDataFrame
 from pyiron_nodes.math_utils import Linspace
-from core import Workflow
-from core import group_node
 
 # ── Group node factories ─────────────────────────────
 
@@ -29,15 +28,15 @@ def CreateDefectStructures(
     in point_defects_metals.py, packaged as a group node so it can feed
     into an energy/formation-energy pipeline like the one below.
     """
+    from core import Workflow
     from pyiron_nodes.atomistic.structure.build import Bulk
-    from pyiron_nodes.atomistic.structure.transform import Repeat
     from pyiron_nodes.atomistic.structure.container_new import (
         AddPristine,
         CreateDefectFromIds,
-        GetVoronoiInterstitialSites,
         GetStructureTable,
+        GetVoronoiInterstitialSites,
     )
-    from core import Workflow
+    from pyiron_nodes.atomistic.structure.transform import Repeat
 
     inner_wf = Workflow("CreateDefectStructures")
     inner_wf.Bulk = Bulk(name=name, cubic=cubic)
@@ -85,9 +84,9 @@ def CreateDefectStructures(
 
 @group_node("energy")
 def group_GRACE_StaticEnergy(structure):
+    from core import Workflow
     from pyiron_nodes.atomistic.calculator.ase import StaticEnergy
     from pyiron_nodes.atomistic.engine.ase import GRACE
-    from core import Workflow
 
     inner_wf = Workflow("group_GRACE_StaticEnergy")
     inner_wf.GRACE = GRACE()

--- a/Workflows/point_defects_metals.py
+++ b/Workflows/point_defects_metals.py
@@ -1,13 +1,13 @@
+from core import Workflow
 from pyiron_nodes.atomistic.structure.build import Bulk
-from pyiron_nodes.atomistic.structure.transform import Repeat
 from pyiron_nodes.atomistic.structure.container_new import (
     AddPristine,
     CreateDefectFromIds,
-    GetVoronoiInterstitialSites,
-    GetStructureTable,
     GetDefectTable,
+    GetStructureTable,
+    GetVoronoiInterstitialSites,
 )
-from core import Workflow
+from pyiron_nodes.atomistic.structure.transform import Repeat
 
 wf = Workflow("point_defects_metals")
 

--- a/Workflows/relax_vs_static.py
+++ b/Workflows/relax_vs_static.py
@@ -1,4 +1,6 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.engine.ase import GRACE
+from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.controls import IterToDataFrame
 from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
     GenericOptimizerSettings,
@@ -6,11 +8,8 @@ from pyiron_nodes.dpg2026.atomistic.calculator.optimize import (
     Relax,
     Static,
 )
-from pyiron_nodes.atomistic.structure.build import Bulk
 from pyiron_nodes.math_utils import Linspace
 from pyiron_nodes.plotting import InputPlotOptions, MergePlots, PlotDataFrame
-from core import Workflow
-from core import group_node
 
 wf = Workflow("relax_vs_static")
 

--- a/Workflows/tip3p_slab_md.py
+++ b/Workflows/tip3p_slab_md.py
@@ -1,3 +1,4 @@
+from core import Workflow, group_node
 from pyiron_nodes.atomistic.calculator.data import InputCalcMD, OutputCalcMD
 from pyiron_nodes.atomistic.engine.lammps import (
     CreateLammpsMDInput,
@@ -10,8 +11,6 @@ from pyiron_nodes.atomistic.structure.view import Animate
 from pyiron_nodes.electrochemistry.structure.build import AddNeonLayer, AddWaterFilm
 from pyiron_nodes.electrochemistry.structure.equilibrate import TIP3PSlabPotential
 from pyiron_nodes.plotting import Plot
-from core import Workflow
-from core import group_node
 
 wf = Workflow("tip3p_slab_md")
 

--- a/Workflows/whileloop.py_fix.py
+++ b/Workflows/whileloop.py_fix.py
@@ -1,6 +1,4 @@
-from core import Workflow
-from core import group_node
-from core import as_function_node
+from core import Workflow, as_function_node, group_node
 
 # ── Local node definitions ──────────────────────
 

--- a/tests/unit/engine/test_lammps.py
+++ b/tests/unit/engine/test_lammps.py
@@ -1,13 +1,13 @@
 import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
-
-import tempfile
 
 import pandas as pd
 from ase.build import bulk, molecule
 
+from pyiron_nodes.atomistic.calculator.data import InputCalcMD
 from pyiron_nodes.atomistic.engine.lammps import (
     CreateLammpsMDInput,
     CreateLammpsStructure,
@@ -18,7 +18,6 @@ from pyiron_nodes.atomistic.engine.lammps import (
     extract_charges_from_lammps_potential,
     write_lammps_data_full,
 )
-from pyiron_nodes.atomistic.calculator.data import InputCalcMD
 from pyiron_nodes.electrochemistry.structure.equilibrate import TIP3PSlabPotential
 
 AL_POTENTIAL = "1999--Mishin-Y--Al--LAMMPS--ipr1"

--- a/tests/unit/machine_learning/test_models.py
+++ b/tests/unit/machine_learning/test_models.py
@@ -6,46 +6,46 @@ in the pyiron_nodes package. Tests cover initialization, training, prediction,
 edge cases, and integration with the pyiron workflow system.
 """
 
+import contextlib
 import unittest
-from typing import Tuple
 
 import numpy as np
 import pandas as pd
 
 from pyiron_nodes.machine_learning.models import (
-    # Linear models
-    LinearRegressionModel,
-    RidgeRegressionModel,
-    LassoRegressionModel,
-    ElasticNetRegressionModel,
-    LogisticClassificationModel,
-    # Tree models
-    DecisionTreeRegressionModel,
-    DecisionTreeClassificationModel,
-    # Random Forest
-    RandomForestRegressionModel,
-    RandomForestClassificationModel,
-    # Gradient Boosting
-    GradientBoostingRegressionModel,
-    GradientBoostingClassificationModel,
+    AdaBoostClassificationModel,
     # AdaBoost
     AdaBoostRegressionModel,
-    AdaBoostClassificationModel,
+    CompareClassificationModels,
+    # Comparison
+    CompareRegressionModels,
+    DecisionTreeClassificationModel,
+    # Tree models
+    DecisionTreeRegressionModel,
+    ElasticNetRegressionModel,
+    EvaluateClassificationModelSklearn,
+    # Evaluation
+    EvaluateRegressionModelSklearn,
+    GradientBoostingClassificationModel,
+    # Gradient Boosting
+    GradientBoostingRegressionModel,
+    KNeighborsClassificationModel,
     # KNeighbors
     KNeighborsRegressionModel,
-    KNeighborsClassificationModel,
+    LassoRegressionModel,
+    # Linear models
+    LinearRegressionModel,
+    LogisticClassificationModel,
+    PredictClassificationModel,
+    # Prediction
+    PredictRegressionModel,
+    RandomForestClassificationModel,
+    # Random Forest
+    RandomForestRegressionModel,
+    RidgeRegressionModel,
     # SVM
     SupportVectorClassificationModel,
     SupportVectorRegressionModel,
-    # Evaluation
-    EvaluateRegressionModelSklearn,
-    EvaluateClassificationModelSklearn,
-    # Prediction
-    PredictRegressionModel,
-    PredictClassificationModel,
-    # Comparison
-    CompareRegressionModels,
-    CompareClassificationModels,
 )
 
 # =============================================================================
@@ -53,7 +53,7 @@ from pyiron_nodes.machine_learning.models import (
 # =============================================================================
 
 
-def regression_data() -> Tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]:
+def regression_data() -> tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]:
     """Generate synthetic regression dataset: (X_train, y_train, X_test, y_test)."""
     np.random.seed(42)
     n_train, n_test, n_features = 50, 20, 5
@@ -80,7 +80,7 @@ def regression_data() -> Tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]
 
 
 def binary_classification_data() -> (
-    Tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]
+    tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]
 ):
     """Generate synthetic binary classification dataset."""
     np.random.seed(42)
@@ -106,7 +106,7 @@ def binary_classification_data() -> (
 
 
 def multiclass_classification_data() -> (
-    Tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]
+    tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]
 ):
     """Generate synthetic multiclass (3-class) classification dataset."""
     np.random.seed(42)
@@ -133,14 +133,14 @@ def multiclass_classification_data() -> (
     return X_train, y_train, X_test, y_test
 
 
-def empty_data() -> Tuple[pd.DataFrame, pd.Series]:
+def empty_data() -> tuple[pd.DataFrame, pd.Series]:
     """Generate an empty dataset."""
     X_empty = pd.DataFrame(np.empty((0, 5)), columns=[f"feature_{i}" for i in range(5)])
     y_empty = pd.Series([], dtype=float, name="target")
     return X_empty, y_empty
 
 
-def single_sample_data() -> Tuple[pd.DataFrame, pd.Series]:
+def single_sample_data() -> tuple[pd.DataFrame, pd.Series]:
     """Generate a single-sample dataset."""
     np.random.seed(42)
     X_single = pd.DataFrame(
@@ -872,20 +872,16 @@ class TestEdgeCases(unittest.TestCase):
         X_nan.iloc[:, 0] = np.nan
 
         # Should either handle gracefully or raise appropriate error
-        try:
+        with contextlib.suppress(ValueError, RuntimeError):
             LinearRegressionModel._original_func(X_nan, y_train)
-        except (ValueError, RuntimeError):
-            pass  # Expected behavior
 
     def test_infinity_values(self):
         X_train, y_train, _, _ = regression_data()
         X_inf = X_train.copy()
         X_inf.iloc[0, 0] = np.inf
 
-        try:
+        with contextlib.suppress(ValueError, RuntimeError):
             LinearRegressionModel._original_func(X_inf, y_train)
-        except (ValueError, RuntimeError):
-            pass  # Expected behavior
 
 
 # =============================================================================

--- a/tests/unit/structure/test_container_new.py
+++ b/tests/unit/structure/test_container_new.py
@@ -2,61 +2,57 @@ import subprocess
 import sys
 import unittest
 from pathlib import Path
-from unittest import mock
 
 import numpy as np
 from ase.build import bulk
 
-import pyiron_nodes.atomistic.structure.container_new as container_new
 from pyiron_nodes.atomistic.structure.container_new import (
-    StructureContainer,
     AddPristine,
-    CreateDefectFromIds,
-    CreateDefectFromSeed,
     CreateDefectBatchFromIds,
     CreateDefectBatchFromSeed,
-    GetStoichiometry,
-    ValidateStructure,
+    CreateDefectFromIds,
+    CreateDefectFromSeed,
     ElementUids,
-    FindStructureIndex,
-    GetVacancyDistances,
-    GetSubstitutionDistances,
-    GetSubstitutionDistancesRelaxed,
-    GetInterstitialDistances,
-    GetInterstitialDistancesRelaxed,
-    GetVoronoiInterstitialSites,
-    GetVoronoiInterstitialSitesPymatgen,
-    GetDelaunayInterstitialSites,
+    FilterByElementCount,
     FilterByGeneration,
-    FilterByStoichiometry,
     FilterByIndices,
     FilterByMaxGeneration,
-    FilterByOperationsShort,
-    FilterByOperationsContains,
-    FilterByUniqueId,
     FilterByNumberOfAtoms,
-    FilterByElementCount,
+    FilterByOperationsContains,
+    FilterByOperationsShort,
     FilterByParent,
-    filter_by_condition,
+    FilterByStoichiometry,
+    FilterByUniqueId,
+    FindStructureIndex,
+    GetDefectStructures,
+    GetDefectTable,
+    GetDelaunayInterstitialSites,
+    GetInterstitialDistances,
+    GetInterstitialDistancesRelaxed,
+    GetPristineStructures,
+    GetPristineTable,
+    GetStoichiometry,
     GetStructure,
     GetStructureTable,
-    GetDefectTable,
-    GetPristineTable,
-    GetPristineStructures,
-    GetDefectStructures,
+    GetSubstitutionDistances,
+    GetSubstitutionDistancesRelaxed,
+    GetVacancyDistances,
+    GetVoronoiInterstitialSites,
+    GetVoronoiInterstitialSitesPymatgen,
     LatestPristineIndex,
-    ResolveDefectRow,
     ResolveAnyRow,
+    ResolveDefectRow,
+    StructureContainer,
+    ValidateStructure,
+    _filter_cluster_tile_interstitial_candidates,
+    _protected_uids_from_events,
+    _resolve_parent,
     ensure_uids,
+    filter_by_condition,
+    make_operations_short,
     next_uid,
     uid_to_index,
     validate_atoms_arrays,
-    make_operations_short,
-    _protected_uids_from_events,
-    _resolve_parent,
-    _filter_cluster_tile_interstitial_candidates,
-    _deduplicate_frac,
-    _extract_defect_frac_coords,
 )
 
 try:
@@ -592,12 +588,12 @@ class TestTableAndSelectionWrappers(unittest.TestCase):
     def test_get_defect_table(self):
         df = GetDefectTable._original_func(self.container)
         self.assertEqual(len(df), 2)
-        self.assertTrue((df["is_pristine"] == False).all())
+        self.assertTrue((~df["is_pristine"]).all())
 
     def test_get_pristine_table(self):
         df = GetPristineTable._original_func(self.container)
         self.assertEqual(len(df), 1)
-        self.assertTrue((df["is_pristine"] == True).all())
+        self.assertTrue(df["is_pristine"].all())
 
     def test_get_pristine_structures(self):
         rows = GetPristineStructures._original_func(self.container)
@@ -1257,6 +1253,7 @@ class TestOptionalDependencyFlagsFallback(unittest.TestCase):
             capture_output=True,
             text=True,
             cwd=repo_root,
+            check=False,
         )
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("OK", result.stdout)


### PR DESCRIPTION
Import sorting/merging (I001), unused imports (F401), unused-alias style (PLR0402), True/False equality comparisons (E712), missing subprocess check= (PLW1510), and try/except/pass -> contextlib.suppress (SIM105) across Workflows/ scripts and the unit test suite. Also adds the missing `Atoms` import in mg_ca_surface_diagram.py (F821).

No behavioral changes -- only import ordering/merging and equivalent rewrites.